### PR TITLE
Add checks when adding an interface

### DIFF
--- a/device/device.go
+++ b/device/device.go
@@ -177,9 +177,35 @@ func (d *Device) IsConnected() bool {
 	return false
 }
 
-// AddInterface adds an interface to the device
-func (d *Device) AddInterface(astarteInterface interfaces.AstarteInterface) {
+// AddInterface adds an interface to the device. The interface must be loaded with ParseInterface
+// from the astarte-go/interfaces package.
+// AddInterface returns `nil` if the interface was loaded successfully, or a corresponding error
+// otherwise (e.g. interface validation failed).
+func (d *Device) AddInterface(astarteInterface interfaces.AstarteInterface) error {
+	if err := astarteInterface.Aggregation.IsValid(); err != nil {
+		return err
+	}
+	if err := astarteInterface.Type.IsValid(); err != nil {
+		return err
+	}
+	if err := astarteInterface.Ownership.IsValid(); err != nil {
+		return err
+	}
+
+	for _, mapping := range astarteInterface.Mappings {
+		if err := mapping.Reliability.IsValid(); err != nil {
+			return err
+		}
+		if err := mapping.Retention.IsValid(); err != nil {
+			return err
+		}
+		if err := mapping.DatabaseRetentionPolicy.IsValid(); err != nil {
+			return err
+		}
+	}
+
 	d.interfaces[astarteInterface.Name] = astarteInterface
+	return nil
 }
 
 // RemoveInterface removes an interface from the device

--- a/examples/basic_device.go
+++ b/examples/basic_device.go
@@ -60,7 +60,11 @@ func ExecuteBasicDevice() {
 		fmt.Println(err.Error())
 		os.Exit(1)
 	}
-	d.AddInterface(iface)
+
+	if err = d.AddInterface(iface); err != nil {
+		fmt.Println(err.Error())
+		os.Exit(1)
+	}
 
 	// Set up device options and callbacks
 	d.AutoReconnect = true

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/astarte-platform/astarte-device-sdk-go
 go 1.14
 
 require (
-	github.com/astarte-platform/astarte-go v0.0.0-20210219104629-4a237278377b
+	github.com/astarte-platform/astarte-go v0.90.1
 	github.com/eclipse/paho.mqtt.golang v1.3.2
 	go.mongodb.org/mongo-driver v1.4.6
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/astarte-platform/astarte-go v0.0.0-20210219104629-4a237278377b h1:zdeYDwlOGD4IysbnmGxvqzgW90X37oy1EzPR1UV05EY=
-github.com/astarte-platform/astarte-go v0.0.0-20210219104629-4a237278377b/go.mod h1:mW8KuuYUMvO91z4HHYpa3e841jZPnp269fuXGl+c8WU=
+github.com/astarte-platform/astarte-go v0.90.1 h1:FP7Uy4Hce0/x1z6gHCypjUCx52R+/OAfZUv0s7qsOts=
+github.com/astarte-platform/astarte-go v0.90.1/go.mod h1:mW8KuuYUMvO91z4HHYpa3e841jZPnp269fuXGl+c8WU=
 github.com/aws/aws-sdk-go v1.34.28/go.mod h1:H7NKnBqNVzoTJpGfLrQkkD+ytBA93eiDYi/+8rV9s48=
 github.com/cristalhq/jwt/v3 v3.0.11 h1:oQAo2wlS8O/BUG03yIlDRzBrCwdAOiP52M1QRCk7MzI=
 github.com/cristalhq/jwt/v3 v3.0.11/go.mod h1:XOnIXst8ozq/esy5N1XOlSyQqBd+84fxJ99FK+1jgL8=


### PR DESCRIPTION
+ The interface might have undefined fields: in this case return an error before adding the interface to the device.
+ Adapt example to handle the error