### PR TITLE
Enable retry if the first connection fails

### DIFF
--- a/device/pairing.go
+++ b/device/pairing.go
@@ -50,11 +50,12 @@ func (d *Device) obtainNewCertificate() error {
 	return d.saveCertificateFromString(cert)
 }
 
-func (d *Device) getBrokerURL() (string, error) {
+func (d *Device) ensureBrokerURL() error {
 	info, err := d.astarteAPIClient.Pairing.GetMQTTv1ProtocolInformationForDevice(d.realm, d.deviceID)
 	if err != nil {
-		return "", err
+		return err
 	}
 
-	return strings.Replace(info.BrokerURL, "mqtts", "ssl", 1), nil
+	d.brokerURL = strings.Replace(info.BrokerURL, "mqtts", "ssl", 1)
+	return nil
 }

--- a/examples/basic_device.go
+++ b/examples/basic_device.go
@@ -68,6 +68,8 @@ func ExecuteBasicDevice() {
 
 	// Set up device options and callbacks
 	d.AutoReconnect = true
+	d.ConnectRetry = true
+	d.MaxRetries = 10
 	d.OnConnectionStateChanged = func(d *device.Device, state bool) {
 		fmt.Printf("Device connection state: %t\n", state)
 	}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.14
 
 require (
 	github.com/astarte-platform/astarte-go v0.90.1
+	github.com/cenkalti/backoff/v4 v4.1.0
 	github.com/eclipse/paho.mqtt.golang v1.3.2
 	go.mongodb.org/mongo-driver v1.4.6
 )

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/astarte-platform/astarte-go v0.90.1 h1:FP7Uy4Hce0/x1z6gHCypjUCx52R+/OAfZUv0s7qsOts=
 github.com/astarte-platform/astarte-go v0.90.1/go.mod h1:mW8KuuYUMvO91z4HHYpa3e841jZPnp269fuXGl+c8WU=
 github.com/aws/aws-sdk-go v1.34.28/go.mod h1:H7NKnBqNVzoTJpGfLrQkkD+ytBA93eiDYi/+8rV9s48=
+github.com/cenkalti/backoff/v4 v4.1.0 h1:c8LkOFQTzuO0WBM/ae5HdGQuZPfPxp7lqBRwQRm4fSc=
+github.com/cenkalti/backoff/v4 v4.1.0/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/cristalhq/jwt/v3 v3.0.11 h1:oQAo2wlS8O/BUG03yIlDRzBrCwdAOiP52M1QRCk7MzI=
 github.com/cristalhq/jwt/v3 v3.0.11/go.mod h1:XOnIXst8ozq/esy5N1XOlSyQqBd+84fxJ99FK+1jgL8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
If the network is not available when the first connection is to be established, and `ConnectRetry` is set to true, try to reconnect for `MaxRetries` times. The interval between retries follows an exponential path and is capped at 60 seconds.
Retry logic employs github.com/cenkalti/backoff/v4