### PR TITLE
Optionally ignore SSL errors

### DIFF
--- a/device/crypto.go
+++ b/device/crypto.go
@@ -77,6 +77,7 @@ func (d *Device) getTLSConfig() (*tls.Config, error) {
 	tlsConfig := new(tls.Config)
 	tlsConfig.Certificates = []tls.Certificate{cert}
 	tlsConfig.RootCAs = d.RootCAs
+	tlsConfig.InsecureSkipVerify = d.IgnoreSSLErrors
 
 	return tlsConfig, nil
 }

--- a/device/device.go
+++ b/device/device.go
@@ -40,6 +40,10 @@ type Device struct {
 	interfaces       map[string]interfaces.AstarteInterface
 	astarteAPIClient *client.Client
 	brokerURL        string
+	// IgnoreSSLErrors allows the device to ignore client SSL errors during connection.
+	// Useful if you're using the device to connect to a test instance of Astarte with self signed certificates,
+	// it is not recommended to leave this to `true` in production. Defaults to `false`.
+	IgnoreSSLErrors bool
 	// AutoReconnect sets whether the device should reconnect automatically if it loses the connection
 	// after establishing it. Defaults to false.
 	AutoReconnect bool


### PR DESCRIPTION
Allow to ignore SSL client errors, as already done e.g. in the [Elixir SDK](https://github.com/astarte-platform/astarte-device-sdk-elixir/blob/fbd0c214f3e2e1d3040fa70d6c2a0d35dab0a495/lib/astarte_device.ex#L94).

