### PR TITLE
store/api: Allow specifying the DB storage explicitly

### DIFF
--- a/device/store.go
+++ b/device/store.go
@@ -47,7 +47,7 @@ type property struct {
 	RawValue       []byte `gorm:"not null"`
 }
 
-func (d *Device) getDbDir() string {
+func (d *Device) getDefaultDbDir() string {
 	dbDir := filepath.Join(d.persistencyDir, "db")
 	os.MkdirAll(dbDir, 0700)
 	return dbDir
@@ -242,6 +242,10 @@ func (d *Device) handlePurgeProperties(payload []byte) error {
 }
 
 func (d *Device) retrieveDevicePropertiesFromStorage() []property {
+	if d.db == nil {
+		return []property{}
+	}
+
 	var properties []property
 	d.db.Find(&properties)
 	upToDate := []property{}


### PR DESCRIPTION
On one hand, this allows users more control over what they want to use (in fact, this opens the door to any gorm supported DB), on the other one it relieves the requirement of using CGO at all times and even not using any storage at all. All of this without changing the APIs.

The only behavior change (which doesn't matter much as it matches the behavior of the SDK up until a couple days ago) is that when no persistency is specified, no databases will be created.

Fixes #21 