### PR TITLE
Handle introspection in the right way upon connecting

### DIFF
--- a/device/device.go
+++ b/device/device.go
@@ -47,6 +47,7 @@ type Device struct {
 	messageQueue            chan astarteMessageInfo
 	isSendingStoredMessages bool
 	volatileMessages        []astarteMessageInfo
+	lastSentIntrospection   string
 	// MaxInflightMessages is the maximum number of messages that can be in publishing channel at any given time
 	// before adding messages becomes blocking. Defaults to 100.
 	MaxInflightMessages int


### PR DESCRIPTION
The current behavior left a number of corner cases running around. Instead, like other SDKs:

1) When the DB is available, store the last sent introspection on success
2) When connecting, if the introspection of the device doesn't match the last one sent, consider everything as a dirty session.