### PR TITLE
Lint GH Workflow: upgrade `golangci-lint-action`

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -26,7 +26,11 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
+    # Since v3, golangci-lint needs explicit go-setup
+    - uses: actions/setup-go@v2
+      with:
+        go-version: v1.14.x
     # Run golint-ci
-    - uses: golangci/golangci-lint-action@v2
+    - uses: golangci/golangci-lint-action@v3
       with:
           version: v1.44


### PR DESCRIPTION
Bump `golangci-lint-action` to `v3` and contextually add a `setup-go` step to use Go 1.14, in order to make the workflow run successfully again without silently downloading the latest Go version. 
See the related discussion on the golangci-lint-action repo:
- https://github.com/golangci/golangci-lint-action/issues/435
- https://github.com/golangci/golangci-lint-action/issues/365 