### PR TITLE
Do not send data before introspection during initialisation

### DIFF
--- a/device/store.go
+++ b/device/store.go
@@ -117,7 +117,7 @@ func (d *Device) resendStoredMessages() {
 	for _, message := range messages {
 		if !isStoredMessageExpired(message) && !d.isInterfaceOutdatedInIntrospection(message.InterfaceName, message.InterfaceMajor) {
 			// if the message is not expired, try resending it
-			d.messageQueue <- message
+			d.inflightMessages.queue <- message
 		} else {
 			// else, it can be removed
 			d.removeFailedMessageFromStorage(message.StorageId)
@@ -135,7 +135,7 @@ func (d *Device) resendVolatileMessages() {
 		d.volatileMessages = d.volatileMessages[1:]
 		// try resending the message only if it is not expired
 		if !isStoredMessageExpired(message) && !d.isInterfaceOutdatedInIntrospection(message.InterfaceName, message.InterfaceMajor) {
-			d.messageQueue <- message
+			d.inflightMessages.queue <- message
 		}
 	}
 }


### PR DESCRIPTION
A race condition on the publisher allowed to send data without having exchanged
Astarte MQTT v1 initialisation messages before, resulting in e.g. introspection
error.
Force message ordering: data can be exchanged only if introspection
has been agreed upon between device and Astarte. This is done via mutex.