### PR TITLE
Device options: allow to change MQTT connection keepalive value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+## Added
+- Introduce the `KeepAlive` device option to configure the MQTT connection keepalive. Default to 30s,
+  which was the value used before.
+
 ## [0.90.2] - 2022-07-04
 ## Added
 - Introduce the `DeviceOptions` struct to expose all possible configuration options for the device.

--- a/device/device_opts.go
+++ b/device/device_opts.go
@@ -17,6 +17,7 @@ package device
 import (
 	"crypto/x509"
 	"errors"
+	"time"
 
 	"gorm.io/gorm"
 )
@@ -50,6 +51,12 @@ type DeviceOptions struct {
 	// UseMqttStore defines whether the SDK will use a store or not for the underlying
 	// MQTT client. It will use the PersistencyDir when it is activated.
 	UseMqttStore bool
+
+	// KeepAlive defines the amount of time that the MQTT client
+	// should wait before sending a PING request to the broker. This will
+	// allow the MQTT client to know that a connection has not been lost with Astarte.
+	// Defaults to 30 seconds.
+	KeepAlive time.Duration
 
 	// PersistencyDir is a known path that will be used by the SDK for MQTT
 	// persistency, for the default database if used, and for crypto storage unless
@@ -96,6 +103,7 @@ func NewDeviceOptions() DeviceOptions {
 		AutoReconnect:       true,
 		ConnectRetry:        true,
 		MaxRetries:          10,
+		KeepAlive:           30 * time.Second,
 	}
 }
 

--- a/device/protocol_mqtt_v1.go
+++ b/device/protocol_mqtt_v1.go
@@ -44,6 +44,7 @@ func (d *Device) initializeMQTTClient() error {
 	opts.SetClientID(fmt.Sprintf("%s/%s", d.realm, d.deviceID))
 	opts.SetConnectTimeout(30 * time.Second)
 	opts.SetCleanSession(false)
+	opts.SetKeepAlive(d.opts.KeepAlive)
 
 	if d.opts.UseMqttStore {
 		s := mqtt.NewFileStore(filepath.Join(d.opts.PersistencyDir, "mqttstore"))


### PR DESCRIPTION
Allow the user to specify a MQTT connection keepalive value different from the default one (30 sec).
Increasing the keepalive will reduce network traffic, but it will take longer to notice that connection went off.
The default value is 30s so as to mantain the previous behaviour.