### PR TITLE
 Upgrade Go to 1.18

### DIFF
--- a/.github/workflows/e2e-test-workflow.yaml
+++ b/.github/workflows/e2e-test-workflow.yaml
@@ -34,8 +34,8 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v2
         with:
-          # Ensure we're on Go 1.17
-          go-version: '1.17.x'
+          # Ensure we're on Go 1.18
+          go-version: '1.18.x'
       - name: Run test
         run: |
           echo $E2E_DEVICE_ID

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -29,8 +29,8 @@ jobs:
     # Since v3, golangci-lint needs explicit go-setup
     - uses: actions/setup-go@v2
       with:
-        go-version: v1.17.x
+        go-version: v1.18.x
     # Run golint-ci
     - uses: golangci/golangci-lint-action@v3
       with:
-          version: v1.44
+          version: v1.50.1

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.17.8
+golang 1.18.8

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/astarte-platform/astarte-device-sdk-go
 
-go 1.17
+go 1.18
 
 require (
 	github.com/astarte-platform/astarte-go v0.90.4


### PR DESCRIPTION
Go 1.17 is supported no more. Bump Go to a supported version.
(also: welcome Go to [1972](https://en.wikipedia.org/wiki/System_F))